### PR TITLE
Revert "Add static label 'site' to all metrics"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ With https://ccremer.github.io/charts/fronius-exporter[fronius-exporter]
 
 [source,console]
 ----
-fronius-exporter --symo.url http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi --symo.site my-site-name
+fronius-exporter --symo.url http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi
 ----
 
 Upon each call to `/metrics`, the exporter will do a GET request on the given URL, and translate the JSON response to Prometheus metrics format.

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -40,7 +39,6 @@ func setupCliFlags(version string, fs *flag.FlagSet, config *Configuration) {
 	fs.StringSlice("symo.header", config.Symo.Headers,
 		"List of \"key: value\" headers to append to the requests going to Fronius Symo. Example: --symo.header \"authorization=Basic <base64>\".")
 	fs.StringP("symo.url", "u", config.Symo.URL, "Target URL of Fronius Symo device.")
-	fs.StringP("symo.site", "s", config.Symo.Site, "Site name of the Fronius Symo device, it's added as a static label to the metrics. Defaults to the hostname in --symo.url.")
 	fs.Int64("symo.timeout", int64(config.Symo.Timeout.Seconds()),
 		"Timeout in seconds when collecting metrics from Fronius Symo. Should not be larger than the scrape interval.")
 
@@ -57,8 +55,6 @@ func postLoadProcess(config *Configuration) {
 		parsedHeaders = splitHeaderStrings(header, parsedHeaders)
 	}
 	config.Symo.Headers = parsedHeaders
-
-	config.Symo.Site = getSiteOrHostName(config.Symo.Site, config.Symo.URL)
 
 	level, err := log.ParseLevel(config.Log.Level)
 	if err != nil {
@@ -133,18 +129,4 @@ func ConvertHeaders(headers []string, header *http.Header) {
 		}).Debug("Using header")
 		header.Set(key, value)
 	}
-}
-
-// getSiteOrHostName returns the site name as it was given in the config.
-// If that's empty, it returns the hostname or IP address given in the Symo URL.
-// If the URL cannot be parsed either, it returns empty string.
-func getSiteOrHostName(site, rawURL string) string {
-	if site != "" {
-		return site
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return ""
-	}
-	return u.Host
 }

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -212,33 +212,3 @@ func Test_parseHeaderString(t *testing.T) {
 		})
 	}
 }
-
-func Test_getSiteOrHostName(t *testing.T) {
-	tests := map[string]struct {
-		site     string
-		url      string
-		expected string
-	}{
-		"GivenEmptySite_ThenReturnHostnameFromURL": {
-			site:     "",
-			url:      "http://hostname.tld:8080/somepath",
-			expected: "hostname.tld:8080",
-		},
-		"GivenConfiguredSite_ThenReturnSameValue": {
-			site:     "my-site",
-			url:      "http://hostname.tld:8080/somepath",
-			expected: "my-site",
-		},
-		"GivenEmptySite_WhenUrlInvalid_ThenReturnEmpty": {
-			site:     "",
-			url:      "hostname.tld",
-			expected: "",
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := getSiteOrHostName(tt.site, tt.url)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -17,7 +17,6 @@ type (
 	// SymoConfig configures the Fronius Symo device
 	SymoConfig struct {
 		URL     string        `koanf:"url"`
-		Site    string        `koanf:"site"`
 		Timeout time.Duration `koanf:"timeout"`
 		Headers []string      `koanf:"header"`
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -12,76 +12,60 @@ import (
 var (
 	namespace           = "fronius"
 	scrapeDurationGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "scrape_duration_seconds",
-		ConstLabels: getConstantLabels(),
-		Help:        "Time it took to scrape the device in seconds",
+		Namespace: namespace,
+		Name:      "scrape_duration_seconds",
+		Help:      "Time it took to scrape the device in seconds",
 	})
 	scrapeErrorCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace:   namespace,
-		Name:        "scrape_error_count",
-		ConstLabels: getConstantLabels(),
-		Help:        "Number of scrape errors",
+		Namespace: namespace,
+		Name:      "scrape_error_count",
+		Help:      "Number of scrape errors",
 	})
 
 	inverterPowerGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "inverter_power",
-		ConstLabels: getConstantLabels(),
-		Help:        "Power flow of the inverter in Watt",
+		Namespace: namespace,
+		Name:      "inverter_power",
+		Help:      "Power flow of the inverter in Watt",
 	}, []string{"inverter"})
 
 	sitePowerLoadGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_power_load",
-		ConstLabels: getConstantLabels(),
-		Help:        "Site power load in Watt",
+		Namespace: namespace,
+		Name:      "site_power_load",
+		Help:      "Site power load in Watt",
 	})
 	sitePowerGridGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_power_grid",
-		ConstLabels: getConstantLabels(),
-		Help:        "Site power supplied to or provided from the grid in Watt",
+		Namespace: namespace,
+		Name:      "site_power_grid",
+		Help:      "Site power supplied to or provided from the grid in Watt",
 	})
 	sitePowerAccuGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_power_accu",
-		ConstLabels: getConstantLabels(),
-		Help:        "Site power supplied to or provided from the accumulator(s) in Watt",
+		Namespace: namespace,
+		Name:      "site_power_accu",
+		Help:      "Site power supplied to or provided from the accumulator(s) in Watt",
 	})
 	sitePowerPhotovoltaicsGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_power_photovoltaic",
-		ConstLabels: getConstantLabels(),
-		Help:        "Site power supplied to or provided from the accumulator(s) in Watt",
+		Namespace: namespace,
+		Name:      "site_power_photovoltaic",
+		Help:      "Site power supplied to or provided from the accumulator(s) in Watt",
 	})
 
 	siteAutonomyRatioGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_autonomy_ratio",
-		ConstLabels: getConstantLabels(),
-		Help:        "Relative autonomy ratio of the site",
+		Namespace: namespace,
+		Name:      "site_autonomy_ratio",
+		Help:      "Relative autonomy ratio of the site",
 	})
 	siteSelfConsumptionRatioGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_selfconsumption_ratio",
-		ConstLabels: getConstantLabels(),
-		Help:        "Relative self consumption ratio of the site",
+		Namespace: namespace,
+		Name:      "site_selfconsumption_ratio",
+		Help:      "Relative self consumption ratio of the site",
 	})
 
 	siteEnergyGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:   namespace,
-		Name:        "site_energy_consumption",
-		ConstLabels: getConstantLabels(),
-		Help:        "Energy consumption in kWh",
+		Namespace: namespace,
+		Name:      "site_energy_consumption",
+		Help:      "Energy consumption in kWh",
 	}, []string{"time_frame"})
 )
-
-func getConstantLabels() prometheus.Labels {
-	return map[string]string{
-		"site": config.Symo.Site,
-	}
-}
 
 func collectMetricsFromTarget(client *fronius.SymoClient) {
 	start := time.Now()


### PR DESCRIPTION
## Summary

This reverts #28 

Adding a static label such as "site" that applies to all metrics should be done via Prometheus relabeling mechanics.
The label itself doesn't provide any functionality.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
