### PR TITLE
Add support for MPPT metrics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ With https://ccremer.github.io/charts/fronius-exporter[fronius-exporter]
 
 [source,console]
 ----
-fronius-exporter --symo.url http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+fronius-exporter --symo.url http://symo.ip.or.hostname
 ----
 
 Upon each call to `/metrics`, the exporter will do a GET request on the given URL, and translate the JSON response to Prometheus metrics format.

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -41,7 +41,8 @@ func setupCliFlags(version string, fs *flag.FlagSet, config *Configuration) {
 	fs.StringP("symo.url", "u", config.Symo.URL, "Target URL of Fronius Symo device.")
 	fs.Int64("symo.timeout", int64(config.Symo.Timeout.Seconds()),
 		"Timeout in seconds when collecting metrics from Fronius Symo. Should not be larger than the scrape interval.")
-
+	fs.Bool("symo.enable-power-flow", config.Symo.PowerFlowEnabled, "Enable/disable scraping of power flow data")
+	fs.Bool("symo.enable-archive", config.Symo.ArchiveEnabled, "Enable/disable scraping of archive data")
 }
 
 func postLoadProcess(config *Configuration) {

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -16,9 +16,11 @@ type (
 	}
 	// SymoConfig configures the Fronius Symo device
 	SymoConfig struct {
-		URL     string        `koanf:"url"`
-		Timeout time.Duration `koanf:"timeout"`
-		Headers []string      `koanf:"header"`
+		URL              string        `koanf:"url"`
+		Timeout          time.Duration `koanf:"timeout"`
+		Headers          []string      `koanf:"header"`
+		PowerFlowEnabled bool          `koanf:"enable-power-flow"`
+		ArchiveEnabled   bool          `koanf:"enable-archive"`
 	}
 )
 
@@ -29,9 +31,11 @@ func NewDefaultConfig() *Configuration {
 			Level: "info",
 		},
 		Symo: SymoConfig{
-			URL:     "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
-			Timeout: 5 * time.Second,
-			Headers: []string{},
+			URL:              "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
+			Timeout:          5 * time.Second,
+			Headers:          []string{},
+			PowerFlowEnabled: true,
+			ArchiveEnabled:   true,
 		},
 		BindAddr: ":8080",
 	}

--- a/main.go
+++ b/main.go
@@ -30,9 +30,11 @@ func main() {
 	headers := http.Header{}
 	cfg.ConvertHeaders(config.Symo.Headers, &headers)
 	symoClient, err := fronius.NewSymoClient(fronius.ClientOptions{
-		URL:     config.Symo.URL,
-		Headers: headers,
-		Timeout: config.Symo.Timeout,
+		URL:              config.Symo.URL,
+		Headers:          headers,
+		Timeout:          config.Symo.Timeout,
+		PowerFlowEnabled: config.Symo.PowerFlowEnabled,
+		ArchiveEnabled:   config.Symo.ArchiveEnabled,
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Cannot initialize Fronius Symo client.")

--- a/pkg/fronius/symo_test.go
+++ b/pkg/fronius/symo_test.go
@@ -36,3 +36,25 @@ func Test_Symo_GetPowerFlowData_GivenUrl_WhenRequestData_ThenParseStruct(t *test
 
 	assert.Equal(t, 34.5, p.Inverters["1"].BatterySoC)
 }
+
+func Test_Symo_GetArchiveData_GivenUrl_WhenRequestData_ThenParseStruct(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		payload, err := ioutil.ReadFile("testdata/test_archive_data.json")
+		require.NoError(t, err)
+		_, _ = rw.Write(payload)
+	}))
+
+	c, err := NewSymoClient(ClientOptions{
+		URL:              server.URL,
+		PowerFlowEnabled: true,
+		ArchiveEnabled:   true,
+	})
+	require.NoError(t, err)
+
+	p, err := c.GetArchiveData()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(13), p["inverter/1"].Data.CurrentDCString1.Values["0"])
+	assert.Equal(t, float64(15.92), p["inverter/1"].Data.CurrentDCString2.Values["0"])
+	assert.Equal(t, float64(425.6), p["inverter/1"].Data.VoltageDCString1.Values["0"])
+	assert.Equal(t, float64(408.90000000000003), p["inverter/1"].Data.VoltageDCString2.Values["0"])
+}

--- a/pkg/fronius/testdata/test_archive_data.json
+++ b/pkg/fronius/testdata/test_archive_data.json
@@ -1,0 +1,68 @@
+{
+    "Body": {
+        "Data": {
+            "inverter/1": {
+                "Data": {
+                    "Current_DC_String_1": {
+                        "Unit": "A",
+                        "Values": {
+                            "0": 13
+                        },
+                        "_comment": "channelId=66050"
+                    },
+                    "Current_DC_String_2": {
+                        "Unit": "A",
+                        "Values": {
+                            "0": 15.92
+                        },
+                        "_comment": "channelId=131586"
+                    },
+                    "Voltage_DC_String_1": {
+                        "Unit": "V",
+                        "Values": {
+                            "0": 425.60000000000002
+                        },
+                        "_comment": "channelId=66049"
+                    },
+                    "Voltage_DC_String_2": {
+                        "Unit": "V",
+                        "Values": {
+                            "0": 408.90000000000003
+                        },
+                        "_comment": "channelId=131585"
+                    }
+                },
+                "DeviceType": 233,
+                "End": "2021-07-29T12:09:59+02:00",
+                "NodeType": 97,
+                "Start": "2021-07-29T12:05:00+02:00"
+            }
+        }
+    },
+    "Head": {
+        "RequestArguments": {
+            "Channel": [
+                "Voltage_DC_String_1",
+                "Current_DC_String_1",
+                "Voltage_DC_String_2",
+                "Current_DC_String_2"
+            ],
+            "DeviceClass": "Inverter",
+            "DeviceId": "1",
+            "EndDate": "2021-07-30T12:09:59+02:00",
+            "HumanReadable": "True",
+            "Scope": "Device",
+            "SeriesType": "Detail",
+            "StartDate": "2021-07-29T12:05:00+02:00"
+        },
+        "Status": {
+            "Code": 0,
+            "ErrorDetail": {
+                "Nodes": []
+            },
+            "Reason": "",
+            "UserMessage": ""
+        },
+        "Timestamp": "2021-08-05T15:39:00+02:00"
+    }
+}


### PR DESCRIPTION
## Summary

* Adds MPPT (Maximum Power Point Tracking) metrics. MPPT metrics are archived by the fronius inverter every 5 mins.
* This results in an additional API request to the Fronius device with the same `--symo.timeout`
* Each API request is done sequentially. That means the total scrape time can be 2x `--symo.timeout`. Please take that into consideration when configuring Prometheus scrape interval
* Adds 2 new flags: `--symo.enable-power-flow`, `--symo.enable-archive` with default values being `true`. With these flags, you can also disable each API endpoint.

## Breaking Changes

* The `--symo.url` flag suggested to use the full URL path like `--symo.url http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi` previously. This has now changed to base host name only, e.g. `--symo.url http://symo.ip.or.hostname` (without trailing slash)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
