### PR TITLE
Fix inverter label in MPPT metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -157,6 +158,7 @@ func parsePowerFlowMetrics(data *fronius.SymoData) {
 func parseArchiveMetrics(data map[string]fronius.InverterArchive) {
 	log.WithField("archiveData", data).Debug("Parsing data.")
 	for key, inverter := range data {
+		key = strings.TrimPrefix(key, "inverter/")
 		siteMPPTCurrentDCGaugeVec.WithLabelValues(key, "1").Set(inverter.Data.CurrentDCString1.Values["0"])
 		siteMPPTCurrentDCGaugeVec.WithLabelValues(key, "2").Set(inverter.Data.CurrentDCString2.Values["0"])
 		siteMPPTVoltageGaugeVec.WithLabelValues(key, "1").Set(inverter.Data.VoltageDCString1.Values["0"])


### PR DESCRIPTION


## Summary

To align with existing inverter numbering.
This inconsistency was introduced in #42 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
