### PR TITLE
Support ARM64 architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -35,12 +41,11 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.SIGNING_KEY }}
 
-      - name: Login to ghcr.io
+      - name: Login to docker.io
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Login to quay.io
         uses: docker/login-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,11 @@ builds:
   - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty
   goarch:
   - amd64
+  - arm64
   goos:
   - linux
+  goarm:
+  - 8
 
 archives:
 - format: binary
@@ -23,17 +26,57 @@ signs:
   args: ["-u", "3E0B9A63FF344E7CB445BD84ED35499391B64DB4", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 dockers:
-- image_templates:
-  - "docker.io/ccremer/fronius-exporter:v{{ .Version }}"
-  - "quay.io/ccremer/fronius-exporter:v{{ .Version }}"
+- goarch: amd64
+  use: buildx
+  build_flag_templates:
+  - "--platform=linux/amd64"
+  image_templates:
+  - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+  - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
 
-    # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
-    # Only the image for the exact version should be pushed.
-  - "{{ if not .Prerelease }}docker.io/ccremer/fronius-exporter:v{{ .Major }}{{ end }}"
-  - "{{ if not .Prerelease }}quay.io/ccremer/fronius-exporter:v{{ .Major }}{{ end }}"
+- goarch: arm64
+  use_buildx: true
+  build_flag_templates:
+    - "--platform=linux/arm64/v8"
+  image_templates:
+  - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+  - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
 
-  - "{{ if not .Prerelease }}docker.io/ccremer/fronius-exporter:latest{{ end }}"
-  - "{{ if not .Prerelease }}quay.io/ccremer/fronius-exporter:latest{{ end }}"
+docker_manifests:
+  # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
+  # Only the image for the exact version should be pushed.
+
+  # Quay.io
+- name_template: "{{ if not .Prerelease }}quay.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
+  image_templates:
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+- name_template: "{{ if not .Prerelease }}quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Major }}{{ end }}"
+  image_templates:
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+- name_template: "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
+  image_templates:
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+# Docker.io
+- name_template: "{{ if not .Prerelease }}docker.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
+  image_templates:
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+- name_template: "{{ if not .Prerelease }}docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Major }}{{ end }}"
+  image_templates:
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+- name_template: "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
+  image_templates:
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
 
 nfpms:
 - vendor: ccremer
@@ -48,6 +91,3 @@ nfpms:
 
 release:
   prerelease: auto
-  github:
-    owner: ccremer
-    name: fronius-exporter

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
   "labels": [
     "dependency"


### PR DESCRIPTION
## Summary

* Adds Docker manifests and configures Goreleaser to build with ARM64 (arm/v8) architecture.
* Fixes #61 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
