### PR TITLE
Switch image registry to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,12 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.SIGNING_KEY }}
 
-      - name: Login to docker.io
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
-      - name: Login to quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_IO_USER }}
-          password: ${{ secrets.QUAY_IO_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build changelog from PRs with labels
         id: build_changelog
@@ -73,3 +67,4 @@ jobs:
           args: release --release-notes .github/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_REPOSITORY: ${{ github.repository }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,52 +31,27 @@ dockers:
   build_flag_templates:
   - "--platform=linux/amd64"
   image_templates:
-  - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-  - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+  - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
 
 - goarch: arm64
   use_buildx: true
   build_flag_templates:
     - "--platform=linux/arm64/v8"
   image_templates:
-  - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
-  - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+  - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
 
 docker_manifests:
-  # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
+  # For prereleases, updating `latest` does not make sense.
   # Only the image for the exact version should be pushed.
-
-  # Quay.io
-- name_template: "{{ if not .Prerelease }}quay.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
+- name_template: "{{ if not .Prerelease }}ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
   image_templates:
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
 
-- name_template: "{{ if not .Prerelease }}quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Major }}{{ end }}"
+- name_template: "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
   image_templates:
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
-
-- name_template: "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
-  image_templates:
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "quay.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
-
-# Docker.io
-- name_template: "{{ if not .Prerelease }}docker.io/{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}"
-  image_templates:
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
-
-- name_template: "{{ if not .Prerelease }}docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Major }}{{ end }}"
-  image_templates:
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
-
-- name_template: "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
-  image_templates:
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
-    - "docker.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
 
 nfpms:
 - vendor: ccremer

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,6 @@ image:https://img.shields.io/codeclimate/maintainability/ccremer/fronius-exporte
 image:https://img.shields.io/codeclimate/coverage/ccremer/fronius-exporter[Tests,link=https://codeclimate.com/github/ccremer/fronius-exporter]
 image:https://img.shields.io/github/v/release/ccremer/fronius-exporter[Releases,link=https://github.com/ccremer/fronius-exporter/releases]
 image:https://img.shields.io/github/license/ccremer/fronius-exporter[License,link=https://github.com/ccremer/fronius-exporter/blob/master/LICENSE]
-image:https://img.shields.io/badge/container-quay.io-blue[Container image,link=https://quay.io/repository/ccremer/fronius-exporter?tab=tags]
 endif::[]
 
 == About
@@ -39,7 +38,7 @@ image::examples/grafana.png[Grafana]
 
 === Docker
 
-. `docker run -d --name fronius-exporter -p "8080:8080" quay.io/ccremer/fronius-exporter --help`
+. `docker run -d --name fronius-exporter -p "8080:8080" ghcr.io/ccremer/fronius-exporter --help`
 
 === Helm Chart
 


### PR DESCRIPTION
## Summary

* Drops `docker.io` and `quay.io` image registries.
* New image registry is `ghcr.io`

NOTE: Users are required to pull from `ghcr.io/ccremer/fronius-exporter` going forward.
The image tags on Docker Hub and quay.io are going to stay for the time being, but no new versions will be pushed there.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
