### PR TITLE
Support arm v7 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   goos:
   - linux
   goarm:
-  - 8
+  - 7
 
 archives:
 - format: binary
@@ -34,11 +34,19 @@ dockers:
   - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
 
 - goarch: arm64
-  use_buildx: true
+  use: buildx
   build_flag_templates:
     - "--platform=linux/arm64/v8"
   image_templates:
   - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+
+- goarch: arm
+  goarm: "7"
+  use: buildx
+  build_flag_templates:
+    - "--platform=linux/arm/v7"
+  image_templates:
+  - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
 
 docker_manifests:
   # For prereleases, updating `latest` does not make sense.
@@ -47,11 +55,13 @@ docker_manifests:
   image_templates:
     - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
     - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
 
 - name_template: "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}"
   image_templates:
     - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-amd64"
     - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-arm64"
+    - "ghcr.io/{{ .Env.IMAGE_REPOSITORY }}:v{{ .Version }}-armv7"
 
 nfpms:
 - vendor: ccremer


### PR DESCRIPTION
## Summary

* Adds `armv7` build and image tags
* Support given as long as Go, Goreleaser and Docker buildx support arm v7

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
