### PR TITLE
enhancement: build also in dockerfile - transparent build different platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,27 @@
+
+FROM golang:1.16-alpine as builder
+
+# Install git + SSL ca certificates.
+# Git is required for fetching the dependencies.
+# Ca-certificates is required to call HTTPS endpoints.
+RUN apk update && apk add --no-cache git ca-certificates tzdata alpine-sdk && update-ca-certificates
+
+ENV CGO_ENABLED=0
+# define RELEASE=1 to hide commit hash
+ARG RELEASE=0
+
+WORKDIR /build
+
+# install go tools and cache modules
+COPY . .
+
+RUN apk add --no-cache curl bash \
+    && make build
+
 FROM docker.io/library/alpine:3.16 as runtime
 
-ENTRYPOINT ["fronius-exporter"]
 
-RUN \
-    apk add --no-cache curl bash
-
-COPY fronius-exporter /usr/bin/
+COPY --from=builder /build/fronius-exporter /usr/bin/
 USER 1000:0
+
+ENTRYPOINT ["/usr/local/bin/fronius-exporter"]

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,8 @@ lint: fmt vet ## Invokes the fmt and vet targets
 	git diff --exit-code
 
 .PHONY: build.docker
-build.docker: export CGO_ENABLED = 0
-build.docker: build ## Build the docker image
-	docker build --tag $(LOCAL_IMG)	.
+build.docker:
+		docker buildx build --platform $(PLATFORM) --tag $(LOCAL_IMG) .
 
 .PHONY: clean
 clean: ## Clean the project

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -9,3 +9,5 @@ BIN_FILENAME ?= fronius-exporter
 # Image URL to use all building/pushing image targets
 IMG_TAG ?= latest
 LOCAL_IMG ?= local.dev/ccremer/fronius-exporter:$(IMG_TAG)
+
+PLATFORM ?= linux/amd64


### PR DESCRIPTION
## Summary

Also run the actual build process of the exporter within the dockerfile - so this is portable to run it also on e.g. raspis with this dockerfile definition

## Checklist

- enhancement 
- no documentation update needed