### PR TITLE
Add GetInverterRealtimeData endpoint

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -43,6 +43,7 @@ func setupCliFlags(version string, fs *flag.FlagSet, config *Configuration) {
 		"Timeout in seconds when collecting metrics from Fronius Symo. Should not be larger than the scrape interval.")
 	fs.Bool("symo.enable-power-flow", config.Symo.PowerFlowEnabled, "Enable/disable scraping of power flow data")
 	fs.Bool("symo.enable-archive", config.Symo.ArchiveEnabled, "Enable/disable scraping of archive data")
+	fs.Bool("symo.enable-inverter-realtime", config.Symo.InverterRealtimeEnabled, "Enable/disable scraping of inverter real time data")
 }
 
 func postLoadProcess(config *Configuration) {

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -16,11 +16,12 @@ type (
 	}
 	// SymoConfig configures the Fronius Symo device
 	SymoConfig struct {
-		URL              string        `koanf:"url"`
-		Timeout          time.Duration `koanf:"timeout"`
-		Headers          []string      `koanf:"header"`
-		PowerFlowEnabled bool          `koanf:"enable-power-flow"`
-		ArchiveEnabled   bool          `koanf:"enable-archive"`
+		URL                     string        `koanf:"url"`
+		Timeout                 time.Duration `koanf:"timeout"`
+		Headers                 []string      `koanf:"header"`
+		PowerFlowEnabled        bool          `koanf:"enable-power-flow"`
+		ArchiveEnabled          bool          `koanf:"enable-archive"`
+		InverterRealtimeEnabled bool          `koanf:"enable-inverter-realtime"`
 	}
 )
 
@@ -31,11 +32,12 @@ func NewDefaultConfig() *Configuration {
 			Level: "info",
 		},
 		Symo: SymoConfig{
-			URL:              "http://symo.ip.or.hostname",
-			Timeout:          5 * time.Second,
-			Headers:          []string{},
-			PowerFlowEnabled: true,
-			ArchiveEnabled:   true,
+			URL:                     "http://symo.ip.or.hostname",
+			Timeout:                 5 * time.Second,
+			Headers:                 []string{},
+			PowerFlowEnabled:        true,
+			ArchiveEnabled:          true,
+			InverterRealtimeEnabled: true,
 		},
 		BindAddr: ":8080",
 	}

--- a/main.go
+++ b/main.go
@@ -30,16 +30,17 @@ func main() {
 	headers := http.Header{}
 	cfg.ConvertHeaders(config.Symo.Headers, &headers)
 	symoClient, err := fronius.NewSymoClient(fronius.ClientOptions{
-		URL:              config.Symo.URL,
-		Headers:          headers,
-		Timeout:          config.Symo.Timeout,
-		PowerFlowEnabled: config.Symo.PowerFlowEnabled,
-		ArchiveEnabled:   config.Symo.ArchiveEnabled,
+		URL:                     config.Symo.URL,
+		Headers:                 headers,
+		Timeout:                 config.Symo.Timeout,
+		PowerFlowEnabled:        config.Symo.PowerFlowEnabled,
+		ArchiveEnabled:          config.Symo.ArchiveEnabled,
+		InverterRealtimeEnabled: config.Symo.InverterRealtimeEnabled,
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Cannot initialize Fronius Symo client.")
 	}
-	if !config.Symo.ArchiveEnabled && !config.Symo.PowerFlowEnabled {
+	if !config.Symo.ArchiveEnabled && !config.Symo.PowerFlowEnabled && !config.Symo.InverterRealtimeEnabled {
 		log.Fatal("All scrape endpoints are disabled. You need enable at least one endpoint.")
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -85,60 +85,60 @@ var (
 		Help:      "Site mppt current DC in A",
 	}, []string{"inverter", "mppt"})
 
-	siteRealtimeDataIDCGauge1 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcCurrentMPPT1Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_idc1",
-		Help:      "Site real time data DC current string 1",
+		Name:      "site_realtime_data_dc_current_mppt1",
+		Help:      "Site real time data DC current MPPT 1 in A",
 	})
-	siteRealtimeDataIDCGauge2 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcCurrentMPPT2Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_idc2",
-		Help:      "Site real time data DC current string 2",
+		Name:      "site_realtime_data_dc_current_mppt2",
+		Help:      "Site real time data DC current MPPT 2 in A",
 	})
-	siteRealtimeDataIDCGauge3 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcCurrentMPPT3Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_idc3",
-		Help:      "Site real time data DC current string 3",
+		Name:      "site_realtime_data_dc_current_mppt3",
+		Help:      "Site real time data DC current MPPT 3 in A",
 	})
-	siteRealtimeDataIDCGauge4 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcCurrentMPPT4Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_idc4",
-		Help:      "Site real time data DC current string 4",
+		Name:      "site_realtime_data_dc_current_mppt4",
+		Help:      "Site real time data DC current MPPT 4 in A",
 	})
-	siteRealtimeDataUDCGauge1 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcVoltageMPPT1Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_udc1",
-		Help:      "Site real time data DC voltage string 1",
+		Name:      "site_realtime_data_dc_voltage_mppt1",
+		Help:      "Site real time data DC voltage MPPT 1 in V",
 	})
-	siteRealtimeDataUDCGauge2 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcVoltageMPPT2Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_udc2",
-		Help:      "Site real time data DC voltage string 2",
+		Name:      "site_realtime_data_dc_voltage_mppt2",
+		Help:      "Site real time data DC voltage MPPT 2 in V",
 	})
-	siteRealtimeDataUDCGauge3 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcVoltageMPPT3Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_udc3",
-		Help:      "Site real time data DC voltage string 3",
+		Name:      "site_realtime_data_dc_voltage_mppt3",
+		Help:      "Site real time data DC voltage MPPT 3 in V",
 	})
-	siteRealtimeDataUDCGauge4 = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataDcVoltageMPPT4Gauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_udc4",
-		Help:      "Site real time data DC voltage string 4",
+		Name:      "site_realtime_data_dc_voltage_mppt4",
+		Help:      "Site real time data DC voltage MPPT 4 in V",
 	})
-	siteRealtimeDataFACGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataAcFrequencyGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_fac",
-		Help:      "Site real time data AC frequency",
+		Name:      "site_realtime_data_ac_frequency",
+		Help:      "Site real time data AC frequency in Hz",
 	})
-	siteRealtimeDataPACGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataAcPowerGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_pac",
-		Help:      "Site real time data AC power",
+		Name:      "site_realtime_data_ac_power",
+		Help:      "Site real time data AC power in W",
 	})
-	siteRealtimeDataTotalEnergyGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	siteRealtimeDataTotalEnergyGeneratedGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "site_realtime_data_total_energy",
-		Help:      "Site real time data total energy",
+		Name:      "site_realtime_data_total_energy_generated",
+		Help:      "Site real time data total energy generated in Wh",
 	})
 )
 
@@ -227,19 +227,19 @@ func parsePowerFlowMetrics(data *fronius.SymoData) {
 
 func parseInverterRealtimeData(data *fronius.SymoInverterRealtimeData) {
 	log.WithField("InverterRealtimeData", *data).Debug("Parsing data.")
-	siteRealtimeDataIDCGauge1.Set(data.IDC1.Value)
-	siteRealtimeDataIDCGauge2.Set(data.IDC2.Value)
-	siteRealtimeDataIDCGauge3.Set(data.IDC3.Value)
-	siteRealtimeDataIDCGauge4.Set(data.IDC4.Value)
+	siteRealtimeDataDcCurrentMPPT1Gauge.Set(data.DcCurrentMPPT1.Value)
+	siteRealtimeDataDcCurrentMPPT2Gauge.Set(data.DcCurrentMPPT2.Value)
+	siteRealtimeDataDcCurrentMPPT3Gauge.Set(data.DcCurrentMPPT3.Value)
+	siteRealtimeDataDcCurrentMPPT4Gauge.Set(data.DcCurrentMPPT4.Value)
 
-	siteRealtimeDataUDCGauge1.Set(data.UDC1.Value)
-	siteRealtimeDataUDCGauge2.Set(data.UDC2.Value)
-	siteRealtimeDataUDCGauge3.Set(data.UDC3.Value)
-	siteRealtimeDataUDCGauge4.Set(data.UDC4.Value)
+	siteRealtimeDataDcVoltageMPPT1Gauge.Set(data.DcVoltageMPPT1.Value)
+	siteRealtimeDataDcVoltageMPPT2Gauge.Set(data.DcVoltageMPPT2.Value)
+	siteRealtimeDataDcVoltageMPPT3Gauge.Set(data.DcVoltageMPPT3.Value)
+	siteRealtimeDataDcVoltageMPPT4Gauge.Set(data.DcVoltageMPPT4.Value)
 
-	siteRealtimeDataFACGauge.Set(data.FAC.Value)
-	siteRealtimeDataPACGauge.Set(data.PAC.Value)
-	siteRealtimeDataTotalEnergyGauge.Set(data.TOTAL_ENERGY.Value)
+	siteRealtimeDataAcFrequencyGauge.Set(data.AcFrequency.Value)
+	siteRealtimeDataAcPowerGauge.Set(data.AcPower.Value)
+	siteRealtimeDataTotalEnergyGeneratedGauge.Set(data.TotalEnergyGenerated.Value)
 }
 
 func parseArchiveMetrics(data map[string]fronius.InverterArchive) {

--- a/metrics.go
+++ b/metrics.go
@@ -125,6 +125,21 @@ var (
 		Name:      "site_realtime_data_udc4",
 		Help:      "Site real time data DC voltage string 4",
 	})
+	siteRealtimeDataFACGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "site_realtime_data_fac",
+		Help:      "Site real time data AC frequency",
+	})
+	siteRealtimeDataPACGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "site_realtime_data_pac",
+		Help:      "Site real time data AC power",
+	})
+	siteRealtimeDataTotalEnergyGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "site_realtime_data_total_energy",
+		Help:      "Site real time data total energy",
+	})
 )
 
 func collectMetricsFromTarget(client *fronius.SymoClient) {
@@ -221,6 +236,10 @@ func parseInverterRealtimeData(data *fronius.SymoInverterRealtimeData) {
 	siteRealtimeDataUDCGauge2.Set(data.UDC2.Value)
 	siteRealtimeDataUDCGauge3.Set(data.UDC3.Value)
 	siteRealtimeDataUDCGauge4.Set(data.UDC4.Value)
+
+	siteRealtimeDataFACGauge.Set(data.FAC.Value)
+	siteRealtimeDataPACGauge.Set(data.PAC.Value)
+	siteRealtimeDataTotalEnergyGauge.Set(data.TOTAL_ENERGY.Value)
 }
 
 func parseArchiveMetrics(data map[string]fronius.InverterArchive) {

--- a/pkg/fronius/symo.go
+++ b/pkg/fronius/symo.go
@@ -13,6 +13,8 @@ const (
 	PowerDataPath = "/solar_api/v1/GetPowerFlowRealtimeData.fcgi"
 	// ArchiveDataPath is the Fronius API URL-path for archive data
 	ArchiveDataPath = "/solar_api/v1/GetArchiveData.cgi?Scope=System&Channel=Voltage_DC_String_1&Channel=Current_DC_String_1&Channel=Voltage_DC_String_2&Channel=Current_DC_String_2&HumanReadable=false"
+	// InverterRealtimeDataPath is the Fronius API URL-path for inverter real time data
+	InverterRealtimeDataPath = "/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=CommonInverterData"
 )
 
 type (
@@ -63,6 +65,28 @@ type (
 		EnergyTotal float64 `json:"E_Total"`
 	}
 
+	symoInverterRealtime struct {
+		Body struct {
+			Data SymoInverterRealtimeData `json:"Data"`
+		}
+	}
+	SymoInverterRealtimeData struct {
+		IDC1 RealTimeDataPoint `json:"IDC"`
+		IDC2 RealTimeDataPoint `json:"IDC_2"`
+		IDC3 RealTimeDataPoint `json:"IDC_3"`
+		IDC4 RealTimeDataPoint `json:"IDC_4"`
+
+		UDC1 RealTimeDataPoint `json:"UDC"`
+		UDC2 RealTimeDataPoint `json:"UDC_2"`
+		UDC3 RealTimeDataPoint `json:"UDC_3"`
+		UDC4 RealTimeDataPoint `json:"UDC_4"`
+	}
+
+	RealTimeDataPoint struct {
+		Unit  string  `json:"Unit"`
+		Value float64 `json:"Value"`
+	}
+
 	// SymoArchive holds the parsed archive data from Symo API
 	symoArchive struct {
 		Body struct {
@@ -93,11 +117,12 @@ type (
 	}
 	// ClientOptions holds some parameters for the SymoClient.
 	ClientOptions struct {
-		URL              string
-		Headers          http.Header
-		Timeout          time.Duration
-		PowerFlowEnabled bool
-		ArchiveEnabled   bool
+		URL                     string
+		Headers                 http.Header
+		Timeout                 time.Duration
+		PowerFlowEnabled        bool
+		ArchiveEnabled          bool
+		InverterRealtimeEnabled bool
 	}
 )
 
@@ -127,6 +152,29 @@ func (c *SymoClient) GetPowerFlowData() (*SymoData, error) {
 	}
 	defer response.Body.Close()
 	p := symoPowerFlow{}
+	err = json.NewDecoder(response.Body).Decode(&p)
+	if err != nil {
+		return nil, err
+	}
+	return &p.Body.Data, nil
+}
+
+// GetPowerFlowData returns the parsed data from the Symo device.
+func (c *SymoClient) GetInverterRealtimeData() (*SymoInverterRealtimeData, error) {
+	u, err := url.Parse(c.Options.URL + InverterRealtimeDataPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c.request.URL = u
+	client := http.DefaultClient
+	client.Timeout = c.Options.Timeout
+	response, err := client.Do(c.request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	p := symoInverterRealtime{}
 	err = json.NewDecoder(response.Body).Decode(&p)
 	if err != nil {
 		return nil, err

--- a/pkg/fronius/symo.go
+++ b/pkg/fronius/symo.go
@@ -71,26 +71,26 @@ type (
 		}
 	}
 	SymoInverterRealtimeData struct {
-		//currents of strings 1 to 4
-		IDC1 RealTimeDataPoint `json:"IDC"`
-		IDC2 RealTimeDataPoint `json:"IDC_2"`
-		IDC3 RealTimeDataPoint `json:"IDC_3"`
-		IDC4 RealTimeDataPoint `json:"IDC_4"`
+		//DC currents of MPPT (Maximum Power Point Tracking) 1 to 4 in ampere
+		DcCurrentMPPT1 RealTimeDataPoint `json:"IDC"`
+		DcCurrentMPPT2 RealTimeDataPoint `json:"IDC_2"`
+		DcCurrentMPPT3 RealTimeDataPoint `json:"IDC_3"`
+		DcCurrentMPPT4 RealTimeDataPoint `json:"IDC_4"`
 
-		//voltages of strings 1 to 4
-		UDC1 RealTimeDataPoint `json:"UDC"`
-		UDC2 RealTimeDataPoint `json:"UDC_2"`
-		UDC3 RealTimeDataPoint `json:"UDC_3"`
-		UDC4 RealTimeDataPoint `json:"UDC_4"`
+		//DC voltages of MPPT (Maximum Power Point Tracking) 1 to 4 in Volt
+		DcVoltageMPPT1 RealTimeDataPoint `json:"UDC"`
+		DcVoltageMPPT2 RealTimeDataPoint `json:"UDC_2"`
+		DcVoltageMPPT3 RealTimeDataPoint `json:"UDC_3"`
+		DcVoltageMPPT4 RealTimeDataPoint `json:"UDC_4"`
 
-		//AC frequency
-		FAC RealTimeDataPoint `json:"FAC"`
+		//AC frequency in Hz
+		AcFrequency RealTimeDataPoint `json:"FAC"`
 
-		//AC power
-		PAC RealTimeDataPoint `json:"PAC"`
+		//AC power in Watt (negative value for consuming power)
+		AcPower RealTimeDataPoint `json:"PAC"`
 
-		//total energy
-		TOTAL_ENERGY RealTimeDataPoint `json:"TOTAL_ENERGY"`
+		//AC Energy generated overall in Wh
+		TotalEnergyGenerated RealTimeDataPoint `json:"TOTAL_ENERGY"`
 	}
 
 	RealTimeDataPoint struct {

--- a/pkg/fronius/symo.go
+++ b/pkg/fronius/symo.go
@@ -71,15 +71,26 @@ type (
 		}
 	}
 	SymoInverterRealtimeData struct {
+		//currents of strings 1 to 4
 		IDC1 RealTimeDataPoint `json:"IDC"`
 		IDC2 RealTimeDataPoint `json:"IDC_2"`
 		IDC3 RealTimeDataPoint `json:"IDC_3"`
 		IDC4 RealTimeDataPoint `json:"IDC_4"`
 
+		//voltages of strings 1 to 4
 		UDC1 RealTimeDataPoint `json:"UDC"`
 		UDC2 RealTimeDataPoint `json:"UDC_2"`
 		UDC3 RealTimeDataPoint `json:"UDC_3"`
 		UDC4 RealTimeDataPoint `json:"UDC_4"`
+
+		//AC frequency
+		FAC RealTimeDataPoint `json:"FAC"`
+
+		//AC power
+		PAC RealTimeDataPoint `json:"PAC"`
+
+		//total energy
+		TOTAL_ENERGY RealTimeDataPoint `json:"TOTAL_ENERGY"`
 	}
 
 	RealTimeDataPoint struct {

--- a/pkg/fronius/symo_test.go
+++ b/pkg/fronius/symo_test.go
@@ -45,9 +45,10 @@ func Test_Symo_GetArchiveData_GivenUrl_WhenRequestData_ThenParseStruct(t *testin
 	}))
 
 	c, err := NewSymoClient(ClientOptions{
-		URL:              server.URL,
-		PowerFlowEnabled: true,
-		ArchiveEnabled:   true,
+		URL:                     server.URL,
+		PowerFlowEnabled:        true,
+		ArchiveEnabled:          true,
+		InverterRealtimeEnabled: true,
 	})
 	require.NoError(t, err)
 

--- a/pkg/fronius/symo_test.go
+++ b/pkg/fronius/symo_test.go
@@ -59,3 +59,51 @@ func Test_Symo_GetArchiveData_GivenUrl_WhenRequestData_ThenParseStruct(t *testin
 	assert.Equal(t, float64(425.6), p["inverter/1"].Data.VoltageDCString1.Values["0"])
 	assert.Equal(t, float64(408.90000000000003), p["inverter/1"].Data.VoltageDCString2.Values["0"])
 }
+
+func Test_Symo_GetInverterRealtimeData_GivenUrl_WhenRequestData_ThenParseStruct(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		payload, err := os.ReadFile("testdata/realtimedata.json")
+		require.NoError(t, err)
+		_, _ = rw.Write(payload)
+	}))
+
+	c, err := NewSymoClient(ClientOptions{
+		URL:                     server.URL,
+		PowerFlowEnabled:        true,
+		ArchiveEnabled:          true,
+		InverterRealtimeEnabled: true,
+	})
+	require.NoError(t, err)
+
+	p, err := c.GetInverterRealtimeData()
+	assert.NoError(t, err)
+
+	//current
+	assert.Equal(t, float64(0.021116470918059349), p.DcCurrentMPPT1.Value)
+	assert.Equal(t, float64(0.01560344360768795), p.DcCurrentMPPT2.Value)
+	assert.Equal(t, float64(0), p.DcCurrentMPPT3.Value)
+	assert.Equal(t, float64(0), p.DcCurrentMPPT4.Value)
+	assert.Equal(t, "A", p.DcCurrentMPPT1.Unit)
+	assert.Equal(t, "A", p.DcCurrentMPPT2.Unit)
+	assert.Equal(t, "A", p.DcCurrentMPPT3.Unit)
+	assert.Equal(t, "A", p.DcCurrentMPPT4.Unit)
+
+	//voltage
+	assert.Equal(t, float64(44.587142944335938), p.DcVoltageMPPT1.Value)
+	assert.Equal(t, float64(72.194984436035156), p.DcVoltageMPPT2.Value)
+	assert.Equal(t, float64(0), p.DcVoltageMPPT3.Value)
+	assert.Equal(t, float64(0), p.DcVoltageMPPT4.Value)
+	assert.Equal(t, "V", p.DcVoltageMPPT1.Unit)
+	assert.Equal(t, "V", p.DcVoltageMPPT2.Unit)
+	assert.Equal(t, "V", p.DcVoltageMPPT3.Unit)
+	assert.Equal(t, "V", p.DcVoltageMPPT4.Unit)
+
+	//AC frequency
+	assert.Equal(t, float64(50.029872894287109), p.AcFrequency.Value)
+
+	//AC power
+	assert.Equal(t, float64(253.71487426757812), p.AcPower.Value)
+
+	//Total energy generated
+	assert.Equal(t, float64(1392623.8052777778), p.TotalEnergyGenerated.Value)
+}

--- a/pkg/fronius/testdata/realtimedata.json
+++ b/pkg/fronius/testdata/realtimedata.json
@@ -1,0 +1,88 @@
+{
+   "Body" : {
+      "Data" : {
+         "DAY_ENERGY" : {
+            "Unit" : "Wh",
+            "Value" : null
+         },
+         "DeviceStatus" : {
+            "ErrorCode" : 0,
+            "InverterState" : "Running",
+            "StatusCode" : 7
+         },
+         "FAC" : {
+            "Unit" : "Hz",
+            "Value" : 50.029872894287109
+         },
+         "IAC" : {
+            "Unit" : "A",
+            "Value" : 1.0811097323894501
+         },
+         "IDC" : {
+            "Unit" : "A",
+            "Value" : 0.021116470918059349
+         },
+         "IDC_2" : {
+            "Unit" : "A",
+            "Value" : 0.01560344360768795
+         },
+         "IDC_3" : {
+            "Unit" : "A",
+            "Value" : null
+         },
+         "IDC_4" : {
+            "Unit" : "A",
+            "Value" : null
+         },
+         "PAC" : {
+            "Unit" : "W",
+            "Value" : 253.71487426757812
+         },
+         "SAC" : {
+            "Unit" : "VA",
+            "Value" : 253.71539306640625
+         },
+         "TOTAL_ENERGY" : {
+            "Unit" : "Wh",
+            "Value" : 1392623.8052777778
+         },
+         "UAC" : {
+            "Unit" : "V",
+            "Value" : 232.35920715332031
+         },
+         "UDC" : {
+            "Unit" : "V",
+            "Value" : 44.587142944335938
+         },
+         "UDC_2" : {
+            "Unit" : "V",
+            "Value" : 72.194984436035156
+         },
+         "UDC_3" : {
+            "Unit" : "V",
+            "Value" : null
+         },
+         "UDC_4" : {
+            "Unit" : "V",
+            "Value" : null
+         },
+         "YEAR_ENERGY" : {
+            "Unit" : "Wh",
+            "Value" : null
+         }
+      }
+   },
+   "Head" : {
+      "RequestArguments" : {
+         "DataCollection" : "CommonInverterData",
+         "DeviceId" : "1",
+         "Scope" : "Device"
+      },
+      "Status" : {
+         "Code" : 0,
+         "Reason" : "",
+         "UserMessage" : ""
+      },
+      "Timestamp" : "2024-09-05T18:37:52+00:00"
+   }
+}


### PR DESCRIPTION
## Summary

I've added the GetInverterRealtimeData endpoint including the most important metrics. 
Current Power per MPPT tracker is NOT included, as it's not part of the API, but can easily be calculated by multiplying current and voltage.
